### PR TITLE
소식 상세 페이지 조회 방식 변경 (feat. graphql)

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,9 +1,9 @@
 /* eslint-disable require-jsdoc */
-import * as functions from "firebase-functions";
-import * as admin from "firebase-admin";
-import algoliasearch from "algoliasearch";
-import * as Helper from "./helper";
-import { DocumentData } from "firebase-admin/firestore";
+import * as functions from 'firebase-functions';
+import * as admin from 'firebase-admin';
+import algoliasearch from 'algoliasearch';
+import * as Helper from './helper';
+import { DocumentData } from 'firebase-admin/firestore';
 
 const firebaseConfig = {
   apiKey: process.env.GATSBY_FIREBASE_API_KEY,
@@ -24,8 +24,8 @@ const algoliaClient = algoliasearch(
   functions.config().algolia.apikey,
 );
 
-const INDEX_NAME = "dev_namsan";
-const REGION = "asia-northeast2";
+const INDEX_NAME = 'dev_namsan';
+const REGION = 'asia-northeast2';
 
 const COLLECTION_INDEX = algoliaClient.initIndex(INDEX_NAME);
 
@@ -48,9 +48,9 @@ const myDataConverter = {
 export const helloWorld = functions
   .region(REGION)
   .https.onRequest(async (request, response) => {
-    console.log("## Request ## >>> ");
+    console.log('## Request ## >>> ');
     try {
-      const collectionRef = firestore.collection("news");
+      const collectionRef = firestore.collection('news');
       const list: any[] = [];
       // 해당 컬렉션에 있는 모든 문서들 가져오기
       await new Promise((resolve, reject) => {
@@ -72,7 +72,7 @@ export const helloWorld = functions
             resolve(list);
           })
           .catch(error => {
-            console.log("Error getting documents: ", error);
+            console.log('Error getting documents: ', error);
           });
       });
 
@@ -81,19 +81,19 @@ export const helloWorld = functions
         autoGenerateObjectIDIfNotExist: true,
       })
         .then(() => {
-          response.send("SUCCESS");
+          response.send('SUCCESS');
         })
-        .catch(res => console.log("Error with: ", res));
+        .catch(res => console.log('Error with: ', res));
     } catch (error) {
       console.log(error);
     }
-    console.log("#### end #### ");
+    console.log('#### end #### ');
   });
 
 // define functions:collectionOnCreate
 export const collectionOnCreate = functions
   .region(REGION)
-  .firestore.document("news/{newsId}")
+  .firestore.document('news/{newsId}')
   .onCreate(async (snapshot: any, context: any) => {
     await saveDocumentInAlgolia(snapshot, context);
   });
@@ -113,7 +113,7 @@ const saveDocumentInAlgolia = async (sanpshot: any, context: any) => {
 
       COLLECTION_INDEX.saveObjects(list, {
         autoGenerateObjectIDIfNotExist: true,
-      }).catch(res => console.log("Error with: ", res));
+      }).catch(res => console.log('Error with: ', res));
     }
   }
 };
@@ -126,7 +126,7 @@ const saveDocumentInAlgolia = async (sanpshot: any, context: any) => {
  */
 export const collectionOnUpdate = functions
   .region(REGION)
-  .firestore.document("news/{newsId}")
+  .firestore.document('news/{newsId}')
   .onUpdate(async (change: any, context: any) => {
     await updateDocumentInAlgolia(context.params.newsId, change);
   });
@@ -136,7 +136,7 @@ const updateDocumentInAlgolia = async (objectID: any, change: any) => {
   const before = change.before.data();
   const after = change.after.data();
   if (before && after) {
-    const news: NewObjectType = { objectId: objectID };
+    const news: NewObjectType = { objectId: '' };
     let flag = false;
     if (before.title !== after.title) {
       news.title = after.title;
@@ -151,7 +151,7 @@ const updateDocumentInAlgolia = async (objectID: any, change: any) => {
     if (flag) {
       COLLECTION_INDEX.partialUpdateObjects([news], {
         autoGenerateObjectIDIfNotExist: true,
-      }).catch(res => console.log("Error with: ", res));
+      }).catch(res => console.log('Error with: ', res));
     }
   }
 };
@@ -159,7 +159,7 @@ const updateDocumentInAlgolia = async (objectID: any, change: any) => {
 // define functions:collectionOnDelete
 export const collectionOnDelete = functions
   .region(REGION)
-  .firestore.document("news/{newsId}")
+  .firestore.document('news/{newsId}')
   .onDelete(async (snapshot: any, context: any) => {
     await deleteDocumentInAlgolia(snapshot);
   });
@@ -168,7 +168,7 @@ const deleteDocumentInAlgolia = async (sanpshot: any) => {
   if (sanpshot.exists) {
     const objectId = sanpshot.data();
     COLLECTION_INDEX.deleteObject(objectId).catch(res =>
-      console.log("Error with: ", res),
+      console.log('Error with: ', res),
     );
   }
 };

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -241,6 +241,13 @@ exports.createPages = async ({ actions, graphql }: any) => {
         edges {
           node {
             id
+            newsType
+            originalLink
+            imagePath
+            title
+            date
+            content
+            agency
           }
         }
       }
@@ -251,7 +258,7 @@ exports.createPages = async ({ actions, graphql }: any) => {
       path: `/news/${node.id}`,
       component: resolve('./src/pages/news/[id].tsx'),
       context: {
-        id: node.id,
+        news: { ...node },
       },
     });
   });

--- a/src/components/news/Card/Card.style.ts
+++ b/src/components/news/Card/Card.style.ts
@@ -11,6 +11,7 @@ import { NewsType } from '@Type/api.type';
 import styled from 'styled-components';
 
 export const CardBox = styled.div`
+  max-width: 1200px;
   margin: 0 auto;
   display: grid;
   gap: 24px;
@@ -23,6 +24,7 @@ export const CardBox = styled.div`
 
 export const Card = styled.a`
   ${size('426px', '384px')}
+  min-width: 265px;
   box-sizing: border-box;
   border: 1px solid ${({ theme }) => theme.color.grey200};
   border-radius: 10px;
@@ -72,7 +74,10 @@ export const LabelBox = styled.div<{ type: NewsType }>`
 `;
 
 export const Title = styled.p`
-  ${size('76px', '320px')}
+  height: 76px;
+  max-width: auto;
+  min-width: 185px;
+
   margin-top: 12px;
   margin-bottom: 16px;
 

--- a/src/components/news/NewsDetail/NewsDetail.interface.ts
+++ b/src/components/news/NewsDetail/NewsDetail.interface.ts
@@ -1,0 +1,4 @@
+import { News } from '@Interface/api.interface';
+import { WrappedComponentProps } from 'gatsby-plugin-intl';
+
+export interface Props extends News, WrappedComponentProps {}

--- a/src/components/news/NewsDetail/NewsDetail.style.ts
+++ b/src/components/news/NewsDetail/NewsDetail.style.ts
@@ -68,6 +68,12 @@ export const ContentConatiner = styled.div`
   ${flexDirection('column')}
   ${size('auto', '792px')}
 
+  .top {
+    ${size('auto', '792px')}
+    text-align: center;
+    margin-bottom: 48px;
+  }
+
   .bottom {
     padding: 80px 0px;
   }

--- a/src/components/news/NewsDetail/NewsDetail.tsx
+++ b/src/components/news/NewsDetail/NewsDetail.tsx
@@ -1,18 +1,24 @@
+import { getFileFromStorage } from '@Api/index.api';
 import BaseButton from '@Components/common/BaseButton';
 import LineArrowIcon from '@Components/icons/LineArrowIcon';
-import { News } from '@Interface/api.interface';
 import { navigate } from 'gatsby';
-import { injectIntl, WrappedComponentProps } from 'gatsby-plugin-intl';
-import React from 'react';
+import { injectIntl } from 'gatsby-plugin-intl';
+import React, { useEffect, useState } from 'react';
 import { convertDateStr } from './NewsDetail.helper';
+import { Props } from './NewsDetail.interface';
 import * as S from './NewsDetail.style';
 
-interface Props extends News, WrappedComponentProps {}
-
 const NewsDetail = (props: Props) => {
-  const { agency, newsType, originalLink, title, content, date } = props;
+  const { agency, newsType, originalLink, title, content, date, imagePath } =
+    props;
   const dateYearMonthDate = convertDateStr(date);
-  
+
+  const [image, setImage] = useState<string>();
+
+  useEffect(() => {
+    imagePath && getFileFromStorage(imagePath).then(setImage);
+  }, []);
+
   const onClickOiriginal = () => {
     window.open(originalLink ?? '', '_blank');
   };
@@ -21,7 +27,7 @@ const NewsDetail = (props: Props) => {
   };
   const handleMove = (event: React.MouseEvent<HTMLButtonElement>) => {};
 
-  const isMediaNews = newsType === 'media';
+  const isMediaNews = newsType === 'media' && image;
   const topTxt = isMediaNews ? agency : '최근 업무사례';
 
   return (
@@ -47,10 +53,11 @@ const NewsDetail = (props: Props) => {
         <S.DateARea>{dateYearMonthDate}</S.DateARea>
       </S.HeaderContainer>
       <S.ContentConatiner>
-        {/* 사진 */}
-        <article className="top">
-          {isMediaNews && <img src="" alt="" />}
-        </article>
+        {isMediaNews && (
+          <article className="top">
+            <img src={image} alt={title} loading={'lazy'} />
+          </article>
+        )}
         <S.Content>{content}</S.Content>
         <article className="bottom">
           {/* 프로필 정보 */}

--- a/src/interface/api.interface.ts
+++ b/src/interface/api.interface.ts
@@ -36,6 +36,7 @@ export interface News {
   date: Timestamp;
   agency: string;
   originalLink: string;
+  imagePath: string;
   newsType: NewsType;
   dateYearMonth?: string;
   dateYearMonthDate?: string;

--- a/src/pages/news/[id].tsx
+++ b/src/pages/news/[id].tsx
@@ -2,18 +2,21 @@ import Layout from '@Components/common/Layout';
 import Loading from '@Components/common/Loading';
 import NewsWrapper from '@Components/news/NewsWrapper';
 import { News } from '@Interface/api.interface';
-import { graphql, PageProps } from 'gatsby';
+import { PageProps } from 'gatsby';
+import { injectIntl, WrappedComponentProps } from 'gatsby-plugin-intl';
 import React, { lazy, Suspense } from 'react';
 const NewsDetail = lazy(() => import('@Components/news/NewsDetail/NewsDetail'));
 
-const NewsDatil: React.FC<PageProps & News> = ({ data }) => {
-  const newsData = (data as any).news;
+interface _PageProps extends PageProps {
+  pageContext: { news: News };
+}
 
+const NewsDatil: React.FC<_PageProps> = ({ pageContext: { news } }) => {
   return (
     <Layout route="newsDetail">
       <NewsWrapper outerPadding="100px 90px 160px" innerWidth="996px">
         <Suspense fallback={<Loading height="500px" />}>
-          <NewsDetail {...newsData} />
+          <NewsDetail {...news} />
         </Suspense>
       </NewsWrapper>
     </Layout>
@@ -21,16 +24,3 @@ const NewsDatil: React.FC<PageProps & News> = ({ data }) => {
 };
 
 export default NewsDatil;
-
-export const query = graphql`
-  query ($id: String) {
-    news(id: { eq: $id }) {
-      newsType
-      originalLink
-      title
-      date
-      content
-      agency
-    }
-  }
-`;


### PR DESCRIPTION
# *반영 브랜치
- Fix/news detail image

# *변경 사항
- `[id].tsx`로 가져오던 방식 -> gatsby-node SSG 조회 방식 변경
- 상단 이미지 조회 추가
- google-function/collectionOnUpdate 함수 objectID 이슈 수정

# 확인 방법(스크린샷 포함)
- 확인할 수 있는 스크린샷을 포함해주세요 (필수는 아닙니다)
