### PR TITLE
[FIX] 구성원 검색 시.대소문자 무관하게 검색 가능하도록 수정

### DIFF
--- a/src/components/members/MemberList/MemberList.tsx
+++ b/src/components/members/MemberList/MemberList.tsx
@@ -22,8 +22,11 @@ const MemberList = ({ intl, members }: IMemberListProps) => {
       };
 
       const newMembers = members.filter(member => {
+        const paramName = params.name?.toUpperCase();
+        const memberName = member.name.toUpperCase();
+
         return (
-          (!params.name || member.name.includes(params.name)) &&
+          (!paramName || memberName.includes(paramName)) &&
           (!params.position || member.position.startsWith(params.position)) &&
           (!params.businessField ||
             member.businessFields.includes(params.businessField)) &&


### PR DESCRIPTION
# *반영 브랜치
- fix/member-search

# *변경 사항
- [FIX] 구성원 검색 시.대소문자 무관하게 검색 가능하도록 수정

# 확인 방법(스크린샷 포함)
- 확인할 수 있는 스크린샷을 포함해주세요 (필수는 아닙니다)
