### PR TITLE
ci: master 배포에 build-info.json 출처 스탬프

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -40,6 +40,14 @@ jobs:
         run: echo "$FIREBASE_ADMIN_KEY_B64" | base64 -d > firebase-key.json
         env:
           FIREBASE_ADMIN_KEY_B64: ${{ secrets.FIREBASE_ADMIN_KEY_B64 }}
+      # 배포 출처 추적용 — UI 비노출 /build-info.json. commit은 실제 빌드된 커밋(git HEAD).
+      - name: Stamp build-info
+        run: |
+          mkdir -p static
+          printf '{"branch":"%s","commit":"%s","channel":"%s","event":"%s","runId":"%s","builtAt":"%s"}\n' \
+            "master" "$(git rev-parse HEAD)" "live" "${{ github.event_name }}" "${{ github.run_id }}" "$(date -u +%FT%TZ)" \
+            > static/build-info.json
+          cat static/build-info.json
       - run: yarn && yarn build
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:


### PR DESCRIPTION
## Summary

master push→live 빌드에 **`/build-info.json`(UI 비노출)** 생성. 배포된 산출물이 어느 branch/commit/channel에서 빌드됐는지 기록해 **live가 정말 master에서 나왔는지 사후 검증** 가능. (develop preview·webhook에는 별도 적용됨.)

## Changes
- `firebase-hosting-merge.yml`: `yarn build` 전에 `static/build-info.json` 생성 스텝. `commit`은 `git rev-parse HEAD`(실제 빌드 커밋).

## Test plan
- [ ] 머지 후 master push → live 배포 → `curl https://www.namsanlaw.com/build-info.json` 가 `{"branch":"master","channel":"live",...}` 반환
- [ ] (참고) develop preview: `branch":"develop","channel":"preview"`

> 머지 시 master push로 live 재배포 트리거(같은 Gatsby 콘텐츠, 새 키). 운영 영향 인지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)