### PR TITLE
fix(news): 이미지 찌그러짐·탭 줄바꿈·프로필 버튼 깜빡임 수정

### DIFF
--- a/src/components/news/Main/Main.style.ts
+++ b/src/components/news/Main/Main.style.ts
@@ -48,6 +48,7 @@ export const TabBox = styled.ul`
 export const Tab = styled.li<{ isActive?: boolean }>`
   ${flex()}
 
+  white-space: nowrap;
   letter-spacing: -0.4px;
 
   font-weight: ${FontWeight.bold};

--- a/src/components/news/NewsDetail/NewsDetail.style.ts
+++ b/src/components/news/NewsDetail/NewsDetail.style.ts
@@ -114,6 +114,13 @@ export const ContentConatiner = styled.div<{ isProfile: boolean }>`
     text-align: center;
     margin-bottom: 48px;
 
+    /* next/image는 width/height 속성으로 비율이 잡히므로, CSS로 width를 줄 땐
+       height: auto를 함께 줘 종횡비를 유지한다(찌그러짐 방지) */
+    img {
+      width: 100%;
+      height: auto;
+    }
+
     ${mediaQuery('tablet1024', `${size('auto', '100%')}margin-bottom: 40px;`)};
   }
 
@@ -122,10 +129,6 @@ export const ContentConatiner = styled.div<{ isProfile: boolean }>`
     @media (max-width: ${ScreenBreakPoints['mobile']}) {
       padding: ${({ isProfile }) => (isProfile ? '52px' : '40px')} 0px 64px;
     }
-  }
-
-  img {
-    width: 100%;
   }
 `;
 

--- a/src/components/news/NewsDetail/NewsDetail.tsx
+++ b/src/components/news/NewsDetail/NewsDetail.tsx
@@ -28,12 +28,13 @@ const NewsDetail = (props: Props) => {
 
   const router = useRouter();
   const dateYearMonthDate = convertDateStr(date).fullDate;
-  const [profile, setProfile] = useState<NewsProfile[] | []>([]);
+  const [profile, setProfile] = useState<NewsProfile[]>([]);
+  const [isProfileLoading, setIsProfileLoading] = useState(true);
 
   useEffect(() => {
-    getNewsMember(id).then(res => {
-      setProfile(res ?? []);
-    });
+    getNewsMember(id)
+      .then(res => setProfile(res ?? []))
+      .finally(() => setIsProfileLoading(false));
   }, []);
 
   const onClickOiriginal = () => {
@@ -55,7 +56,7 @@ const NewsDetail = (props: Props) => {
   const topTxt = isMediaNews ? agency : '최근 업무사례';
 
   const isNewsImageData = !isEmpty(newsImageData);
-  const isProfile = !isEmpty(profile) && profile.length > 0;
+  const isProfile = !isEmpty(profile);
   const isPrevContent = !isEmpty(prevNews);
   const isNextContent = !isEmpty(nextNews);
 
@@ -112,7 +113,9 @@ const NewsDetail = (props: Props) => {
           </ReactMarkdown>
         </S.Content>
         <article className="bottom">
-          {isProfile ? (
+          {/* 프로필 로딩이 끝나기 전엔 아무것도 노출하지 않아 '기사 원문보기'
+              버튼이 먼저 깜빡이는 현상을 막는다 */}
+          {isProfileLoading ? null : isProfile ? (
             <S.ProfileAreaWrapper>
               {profile.map((item, index) => {
                 return (


### PR DESCRIPTION
## Summary

뉴스 상세/목록의 UI 이슈 3건을 현재 Next.js `develop` 기준으로 수정합니다. 단일 커밋이며 기존 디자인 QA 값(탭 padding 8px, 탭/검색 gap 20px)과 충돌 없이 얹혔습니다.

## Changes

- **상세 상단 이미지 찌그러짐**: `next/image`(AppImage)는 `width`/`height` 속성으로 종횡비를 잡는데, `ContentConatiner`의 전역 `img { width: 100% }`가 `height: auto` 없이 width만 덮어써 비율이 깨졌습니다. 전역 규칙을 제거하고 `.top img { width: 100%; height: auto; }`로 스코프했습니다.
- **'최근 업무사례' 탭 2줄 처리**: `Tab`에 `white-space: nowrap;`를 추가해 폰트/문구 길이와 무관하게 항상 한 줄로 표시합니다.
- **프로필 노출 전 '기사 원문보기' 버튼 깜빡임**: `profile`이 빈 배열로 시작해 비동기 `getNewsMember` 응답 전 fallback 버튼이 먼저 노출되던 문제를, `isProfileLoading` 게이트로 로딩 완료 전 미렌더 처리했습니다. (프로필 클릭→멤버 이동 기능은 그대로 유지)
- **정리**: `isProfile`의 중복 조건 `!isEmpty(profile) && profile.length > 0` → `!isEmpty(profile)`.

## Test plan

- [x] `pnpm typecheck` 0 errors
- [x] CI `pnpm build` green (포크 PR #5 빌드 스텝 통과로 확인)
- [ ] preview에서 상단 이미지 비율 정상 / '최근 업무사례' 탭 한 줄 / 프로필 영역 깜빡임 없음 육안 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)