### PR TITLE
fix(news): 프로필 로딩 중 기사 원문보기 버튼 깜빡임 제거

### DIFF
--- a/src/components/news/NewsDetail/NewsDetail.tsx
+++ b/src/components/news/NewsDetail/NewsDetail.tsx
@@ -29,11 +29,16 @@ const NewsDetail = (props: Props) => {
   const router = useRouter();
   const dateYearMonthDate = convertDateStr(date).fullDate;
   const [profile, setProfile] = useState<NewsProfile[] | []>([]);
+  const [profileLoaded, setProfileLoaded] = useState(false);
 
   useEffect(() => {
-    getNewsMember(id).then(res => {
-      setProfile(res ?? []);
-    });
+    getNewsMember(id)
+      .then(res => {
+        setProfile(res ?? []);
+      })
+      .finally(() => {
+        setProfileLoaded(true);
+      });
   }, []);
 
   const onClickOiriginal = () => {
@@ -136,9 +141,11 @@ const NewsDetail = (props: Props) => {
               })}
             </S.ProfileAreaWrapper>
           ) : (
-            <BaseButton className={'support'} onClick={onClickOiriginal}>
-              기사 원문보기
-            </BaseButton>
+            (isMediaNews || profileLoaded) && (
+              <BaseButton className={'support'} onClick={onClickOiriginal}>
+                기사 원문보기
+              </BaseButton>
+            )
           )}
         </article>
       </S.ContentConatiner>


### PR DESCRIPTION
## Summary

뉴스 상세 페이지에서 비-미디어(업무사례) 뉴스의 프로필을 비동기로 가져오는 동안 `기사 원문보기` 버튼이 잠깐 노출됐다 사라지는 깜빡임을 제거했다.

## Changes

- `profileLoaded` 상태 추가 — `getNewsMember` 호출 완료(`.finally`) 시 `true`로 설정
- fallback 버튼 렌더 조건을 `(isMediaNews || profileLoaded)`로 변경
  - 미디어 뉴스: 프로필이 없는 게 정상이고 원문 링크가 목적이므로 기존처럼 즉시 노출
  - 업무사례 뉴스: 프로필 로드가 끝난 뒤에만 fallback 버튼 노출 → 로딩 중 깜빡임 제거

## Test plan

- [ ] `pnpm typecheck && pnpm build` 통과
- [ ] 업무사례 뉴스 상세 진입 시 `기사 원문보기` 버튼이 깜빡이지 않음 (프로필 있으면 프로필만, 없으면 로드 후 버튼)
- [ ] 미디어 뉴스 상세 진입 시 `기사 원문보기` 버튼 정상 노출 + 원문 링크 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)