### PR TITLE
fix(news): prev/next 이동 시 프로필 재요청 (useEffect 의존성에 id 추가)

### DIFF
--- a/src/components/news/NewsDetail/NewsDetail.tsx
+++ b/src/components/news/NewsDetail/NewsDetail.tsx
@@ -32,10 +32,11 @@ const NewsDetail = (props: Props) => {
   const [isProfileLoading, setIsProfileLoading] = useState(true);
 
   useEffect(() => {
+    setIsProfileLoading(true);
     getNewsMember(id)
       .then(res => setProfile(res ?? []))
       .finally(() => setIsProfileLoading(false));
-  }, []);
+  }, [id]);
 
   const onClickOiriginal = () => {
     window.open(originalLink ?? '', '_blank');


### PR DESCRIPTION
## Summary

뉴스 상세에서 이전/다음 글로 이동할 때 프로필이 갱신되지 않고 이전 글의 프로필이 그대로 노출되던 문제를 수정한다.

## Changes

- `NewsDetail.tsx`의 프로필 fetch `useEffect` 의존성을 `[]` → `[id]`로 변경. Next.js가 동일 동적 라우트(`/news/[id]`) 컴포넌트를 언마운트하지 않고 `id` prop만 교체하므로, 기존 `[]` 의존성에서는 최초 마운트 시 한 번만 `getNewsMember`를 호출하여 이동해도 프로필이 그대로 남아 있었다. `[id]`로 변경해 `id`가 바뀔 때마다 재요청한다.
- 재요청 시작 시 `isProfileLoading`을 `true`로 되돌려, 새 프로필 로딩 전 이전 프로필/'기사 원문보기' 버튼이 잠깐 노출되는 깜빡임을 방지한다.

## Test plan

- [ ] `pnpm lint && pnpm tsc && pnpm build` 통과
- [ ] 뉴스 상세에서 이전/다음 화살표 이동 시 각 글의 프로필이 새로 로드되는지 확인
- [ ] 프로필이 없는 글로 이동 시 '기사 원문보기' 버튼이 정상 노출되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)