### PR TITLE
fix(ci): content webhook 배포를 pnpm/Next 빌드로 마이그레이션 (master 정합)

### DIFF
--- a/.github/workflows/firebase-hosting-webhook.yml
+++ b/.github/workflows/firebase-hosting-webhook.yml
@@ -11,12 +11,28 @@ jobs:
     steps:
       # 백오피스 배포 버튼(repository_dispatch)은 운영(live)을 발행한다.
       # 기본 브랜치(develop)가 아니라 항상 master를 빌드해야 "운영=master 기준"이 성립.
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: master
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
       - name: Check Github action trigger
-        run:  |
+        run: |
           echo "Event '${{ github.event.action }}' received from '${{ github.event.client_payload.repository }}'"
+      - name: Cache Next.js build + optimized images
+        uses: actions/cache@v4
+        with:
+          path: |
+            .next/cache
+            public/nextImageExportOptimizer
+            public/images/next-image-export-optimizer-hashes.json
+            remoteImagesForOptimization
+          key: ${{ runner.os }}-namsan-build-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-namsan-build-
       - name: Generate Environment Variables File for Production
         run: |
           echo "NEXT_PUBLIC_FIREBASE_API_KEY=$GATSBY_FIREBASE_API_KEY" >> .env
@@ -34,25 +50,15 @@ jobs:
           GATSBY_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.GATSBY_FIREBASE_MESSAGING_SENDER_ID }}
           GATSBY_FIREBASE_APP_ID: ${{ secrets.GATSBY_FIREBASE_APP_ID }}
           GATSBY_FIREBASE_MEASUREMENT_ID: ${{ secrets.GATSBY_FIREBASE_MEASUREMENT_ID }}
-          GATSBY_ALGOLIA_ID: ${{ secrets.GATSBY_ALGOLIA_ID }}
-          GATSBY_ALGOLIA_SEARCH_KEY: ${{ secrets.GATSBY_ALGOLIA_SEARCH_KEY }}
-          GATSBY_ALGOLIA_INDEX_NAME: ${{ secrets.GATSBY_ALGOLIA_INDEX_NAME }}
-      # gatsby-source-firestore-easy는 빌드 타임에 firebase-key.json(서비스 계정)으로
-      # Firestore를 읽는다. 커밋됐던 키는 폐기되어 untrack → 시크릿에서 주입.
-      - name: Write Firebase admin key
-        run: echo "$FIREBASE_ADMIN_KEY_B64" | base64 -d > firebase-key.json
-        env:
-          FIREBASE_ADMIN_KEY_B64: ${{ secrets.FIREBASE_ADMIN_KEY_B64 }}
-      # 배포 버튼(repository_dispatch)은 ref:master를 빌드 — github.sha(=default branch)가
-      # 아니라 git HEAD(실제 체크아웃된 master 커밋)를 찍어야 정확. UI 비노출 /build-info.json.
+      # 배포 출처 추적용 — UI 비노출 /build-info.json. commit은 실제 빌드된 커밋(git HEAD).
       - name: Stamp build-info
         run: |
-          mkdir -p static
+          mkdir -p public
           printf '{"branch":"%s","commit":"%s","channel":"%s","event":"%s","runId":"%s","builtAt":"%s"}\n' \
             "master" "$(git rev-parse HEAD)" "live" "${{ github.event_name }}" "${{ github.run_id }}" "$(date -u +%FT%TZ)" \
-            > static/build-info.json
-          cat static/build-info.json
-      - run: yarn && yarn build
+            > public/build-info.json
+          cat public/build-info.json
+      - run: pnpm install --frozen-lockfile && pnpm build
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
## Summary

PR #295(→develop)와 동일한 webhook 워크플로 수정을 `master`에도 반영해 브랜치 간 드리프트를 없앤다.

`firebase-hosting-webhook.yml`은 모든 워크플로 중 유일하게 레거시 Gatsby 빌드(`yarn && yarn build`)로 남아 있었고, master는 이미 Next.js+pnpm(`packageManager: pnpm@9.15.4`)이라 yarn 1.22가 빌드를 거부한다. (실행되는 정의는 기본 브랜치 develop에서 읽히므로 기능적 수정은 #295가 담당하지만, master 파일도 같은 모양으로 맞춰 혼선을 제거한다.)

## Changes

- `yarn && yarn build` → `pnpm install --frozen-lockfile && pnpm build`
- `pnpm/action-setup@v4` + `actions/setup-node@v4`(`.nvmrc`, `cache: pnpm`) 추가
- `actions/checkout@v3` → `v4`, Next.js 빌드/최적화 이미지 캐시 추가
- Gatsby 잔재 제거: `GATSBY_ALGOLIA_*` env 3개, `Write Firebase admin key` 스텝
- build-info 경로 `static/` → `public/`
- `ref: master` 체크아웃, `repository_dispatch` 트리거, live 배포 설정은 유지
- `merge.yml` / `pull-request.yml`과 동일한 pnpm 패턴으로 정렬

## Test plan

- [ ] 머지 시 `firebase-hosting-merge.yml`(push:master→live) 빌드/배포 green 확인
- [ ] 백오피스 배포 버튼(`TRIGGER_DEPLOYMENT`)으로 워크플로 트리거 → pnpm 빌드 통과 및 live 배포 성공